### PR TITLE
Add fp option and use tempfile module

### DIFF
--- a/pyvona.py
+++ b/pyvona.py
@@ -100,14 +100,19 @@ class Voice(object):
         file_extension = ".{codec}".format(codec=self.codec)
         filename += file_extension if not filename.endswith(
             file_extension) else ""
+        with open(filename, 'wb') as f:
+            self.fetch_voice_fp(text_to_speak, f)
+
+    def fetch_voice_fp(self, text_to_speak, fp):
+        """Fetch a voice file for given text and save it to the given file pointer
+        """
         r = self._send_amazon_auth_packet_v4(
             'POST', 'tts', 'application/json', '/CreateSpeech', '',
             self._generate_payload(text_to_speak), self._region, self._host)
         if r.content.startswith(b'{'):
             raise PyvonaException('Error fetching voice: {}'.format(r.content))
         else:
-            with open(filename, 'wb') as f:
-                f.write(r.content)
+            fp.write(r.content)
 
     def speak(self, text_to_speak):
         """Speak a given text


### PR DESCRIPTION
This PR adds the option to write the sound data to a file-like object instead of a filename. 
Also, (temporary) usage of ogg codec is now implemented as a context manager to improve reusability.

Last but not least, the speak option no longer writes  temporary data to the hard disk, but creates a [spooled in-memory file-like object](https://docs.python.org/2/library/tempfile.html#tempfile.SpooledTemporaryFile) to save flash write cycles if used on a single board computer (like the Raspberry Pi), which uses an SD card as root fs.

Existing API has not been changed and thus should be backwards compatible.

Both the `tempfile` module & the `contextlib` module are in the python standard library.
