### PR TITLE
Only initialize pygame.mixer if necessary

### DIFF
--- a/pyvona.py
+++ b/pyvona.py
@@ -132,6 +132,8 @@ class Voice(object):
             with self.use_ogg_codec():
                 self.fetch_voice_fp(text_to_speak, f)
             f.seek(0)
+            if not pygame.mixer.get_init():
+                pygame.mixer.init()
             channel = pygame.mixer.Channel(5)
             sound = pygame.mixer.Sound(f)
             channel.play(sound)
@@ -243,5 +245,3 @@ class Voice(object):
         self.speech_rate = 'medium'
         self.sentence_break = 400
         self.paragraph_break = 650
-        if pygame_available:
-            pygame.mixer.init()


### PR DESCRIPTION
Currently, `pygame.mixer.init()` is always called if it's installed - even if the user doesn't need or want it.

If have pygame installed and you configured your audio setup in a way that pygame fails to detect properly, this even produces an error, even if you do not intent to use pygame:

```
error: No available audio device
```

(See [this comment](https://github.com/jasperproject/jasper-client/pull/349#issuecomment-123959599) for details.)

This commit moves the `pygame.mixer.init()` call into the `speak()` method, which is the only location where pygame is actually used. To avoid multiple `pygame.mixer.init()` calls, we test if `pygame.mixer` has already been initialized via `pygame.mixer.get_init()`.
