### PR TITLE
Fixed bug where channel was not found if pygame.mixer was pre-intialized

### DIFF
--- a/pyvona.py
+++ b/pyvona.py
@@ -135,6 +135,11 @@ class Voice(object):
         if not pygame.mixer.get_init():
             pygame.mixer.init()
             channel = pygame.mixer.Channel(5)
+        else:
+            channel = pygame.mixer.find_channel()
+            if channel is None:
+                pygame.mixer.set_num_channels(pygame.mixer.get_num_channels()+1)
+                channel = pygame.mixer.find_channel()
 
         if use_cache is False:
             with tempfile.SpooledTemporaryFile() as f:


### PR DESCRIPTION
If pygame.mixer.init() was run before Voice.speak() was called, then no channel was
assigned for the voice to play on. Now if pygame..mixer.init() was already called, then
an open channel is searched for and the voice is played on that. Otherwise a new
channel is created, and the voice is played on that.
